### PR TITLE
Add timestamp to log formatter settings

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	log.SetFormatter(&logrus.TextFormatter{
 		DisableQuote: true,
 		ForceColors:  true,
+		FullTimestamp: true,
 	})
 
 	// TODO: This is kinda ugly, move state reader into own file and pass state to both BLE and pod


### PR DESCRIPTION
Adds timestamp to logger output.

Before change
```sh
INFO[3298] pkg pod;   *** Waiting for the next command ***
INFO[3298] pkg command; 0x0e; GET_STATUS; HEX, 178da35910030e0100009d
INFO[3298] pkg response 0x1d; HEX, 178da359140a1d18004d6000000397ff0000
writing to websocket
```

After change
```sh
INFO[2024-06-09T00:11:10+02:00] pkg pod;   *** Waiting for the next command ***
INFO[2024-06-09T00:11:18+02:00] pkg command; 0x0e; GET_STATUS; HEX, 178da35a10030e01000357
INFO[2024-06-09T00:11:18+02:00] pkg response 0x1d; HEX, 178da35a140a1d18001f700000000bff0000
writing to websocket
```